### PR TITLE
add 07 prefix code for french mobile 

### DIFF
--- a/data/phone_countries.yml
+++ b/data/phone_countries.yml
@@ -528,7 +528,7 @@
   :char_3_code: FR
   :name: France
   :international_dialing_prefix: "0"
-  :area_code: "[1-6,8-9]"
+  :area_code: "[1-7,8-9]"
 "995": 
   :country_code: "995"
   :national_dialing_prefix: 8*

--- a/test/countries/fr_test.rb
+++ b/test/countries/fr_test.rb
@@ -10,6 +10,10 @@ class FRTest < Test::Unit::TestCase
   def test_mobile
     parse_test('+33 6 11 22 33 44', '33', '6', '11223344')
   end
+  
+  def test_mobile_07
+     parse_test('+33 7 11 22 33 44', '33', '7', '11223344')
+   end
 
   def test_voip
     parse_test('+33 9 11 22 33 44', '33', '9', '11223344')


### PR DESCRIPTION
Hey, 

I modified your gem with a new code of french mobile ( 7 code). I updated the french country with a new area code (phone_countries.yml) and I modified test files (fr_test.rb). 

I can answer at your questions in  my account.

Best regards.

Thx.
