### PR TITLE
Area code for New Zealand

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -104,6 +104,7 @@ Currently tested on:
 [UA] Ukraine
 [US] United States
 [ZA] South Africa
+[NZ] New Zealand
 
 = Known issues
 There's an issue with Germany and area codes.

--- a/data/phone_countries.yml
+++ b/data/phone_countries.yml
@@ -630,11 +630,12 @@
   :international_dialing_prefix: "0"
 "64": 
   :country_code: "64"
-  :national_dialing_prefix: 0 (None fo
-  :char_2_code: 0 (None fo
+  :national_dialing_prefix: 0
+  :char_2_code: 0
   :char_3_code: NZ
   :name: New Zealand
   :international_dialing_prefix: "0"
+  :area_code: "[1-9]"
 "855": 
   :country_code: "855"
   :national_dialing_prefix: "0"


### PR DESCRIPTION
According to http://www.howtocallabroad.com/new-zealand/ New Zealand has 1-digit area code
