### PR TITLE
Memoize country_code_regexp in Country

### DIFF
--- a/lib/country.rb
+++ b/lib/country.rb
@@ -23,7 +23,7 @@ module Phoner
     end
 
     def country_code_regexp
-      Regexp.new("^[+]#{country_code}")    
+      @country_code_regexp ||= Regexp.new("^[+]#{country_code}")    
     end
   end
   


### PR DESCRIPTION
Tiny optimization to memoize `country_code_regexp` in `Country` objects.

(should help large test files if anything)
