### PR TITLE
Add options to valid?

### DIFF
--- a/lib/phone.rb
+++ b/lib/phone.rb
@@ -15,7 +15,7 @@ require "phone/errors"
 
 module Phoner
   class Phone
-    NUMBER = '([0-9]{1,8})$'  
+    NUMBER = '([0-9]{1,8})$'
     DEFAULT_AREA_CODE = '[0-9][0-9][0-9]' # any 3 digits
 
     attr_accessor :country_code, :area_code, :number, :extension
@@ -76,9 +76,9 @@ module Phoner
     end
 
     # is this string a valid phone number?
-    def self.valid?(string)
+    def self.valid?(string, options = {})
       begin
-        parse(string).present?
+        parse(string, options).present?
       # if we encountered exceptions (missing country code, missing area code etc)
       rescue PhoneError
         return false

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -109,6 +109,10 @@ class PhoneTest < Minitest::Test
     assert true, Phoner::Phone.valid?("+17788827175")
   end
 
+  def test_validity_with_country_code
+    assert true, Phoner::Phone.valid?("7788827175", country_code: "1")
+  end
+
   def test_doesnt_validate
     assert_equal Phoner::Phone.valid?('asdas'), false
     assert_equal Phoner::Phone.valid?('385915125486'), false
@@ -124,7 +128,7 @@ class PhoneTest < Minitest::Test
     pn1 = Phoner::Phone.new '5125486', '91', '385'
     pn2 = Phoner::Phone.new '1234567', '91', '385'
     assert pn1 != pn2
-  end  
+  end
 
   def test_find_by_country_isocode
     Phoner::Country.load


### PR DESCRIPTION
The parse method takes an options hash, however there's no way to check validity using the same options hash syntax. This adds the options hash to `#valid?`
