### PR TITLE
Correct area code for Montenegro

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -1069,6 +1069,7 @@
   :char_3_code: ME
   :name: Montenegro
   :international_dialing_prefix: "99"
+  :area_code: "[2-6][0-9]"
 "976": 
   :country_code: "976"
   :national_dialing_prefix: "0"

--- a/test/countries/me_test.rb
+++ b/test/countries/me_test.rb
@@ -1,0 +1,14 @@
+require "helper"
+
+## Montenegro
+class METest < Minitest::Test
+
+  def test_mobile
+    parse_test('+382 69 555 5555', '382', '69', '5555555')
+  end
+
+  def test_local
+    parse_test('+382 20 555 5555', '382', '20', '5555555')
+  end
+
+end


### PR DESCRIPTION
Pattern for extracting 2-digit Montenegro area code (based on http://www.howtocallabroad.com/montenegro/).