### PR TITLE
added conditional extension delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ When given a string, it interpolates the string with the following fields:
 * %f - first @@n1_length characters of number (configured through Phoner::Phone.n1_length), default is 3 (512)
 * %l - last characters of number (5486)
 * %x - the extension number
+* %d{} - characters in brackets will only appear if extension is present
 
 ```ruby
 pn = Phoner::Phone.parse('+385915125486')
 pn.to_s # => "+385915125486"
 pn.format("%A/%f-%l") # => "091/512-5486"
 pn.format("+ %c (%a) %n") # => "+ 385 (91) 5125486"
+pn.format('(%a) %n%d{ ext.}%x') # => "(91) 5125486"
 ```
 
 When given a symbol it is used as a lookup for the format in the <tt>Phoner::Phone.named_formats</tt> hash.
@@ -77,6 +79,7 @@ When given a symbol it is used as a lookup for the format in the <tt>Phoner::Pho
 pn.format(:europe) # => "+385 (0) 91 512 5486"
 pn.format(:us) # => "(234) 123-4567"
 pn.format(:default_with_extension) # => "+3851234567x143"
+pn.format('(%a) %n%d{ ext.}%x') # => "(385) 1234567 ext.143"
 ```
 
 You can add your own custom named formats like so:

--- a/lib/phone.rb
+++ b/lib/phone.rb
@@ -338,6 +338,8 @@ module Phoner
       # TODO: When we drop 1.8.7 we can pass the hash in as an arg to #gsub
       fmt.gsub(FORMAT_TOKENS) do |match|
         replacements[match.to_s]
+      end.gsub(/%d\{(.*?)\}/) do
+        extension.nil? ? '' : $1
       end
     end
   end

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -145,6 +145,18 @@ class PhoneTest < Minitest::Test
     assert_equal pn.format(:europe), '+385 (0) 91 512 5486'
   end
 
+  def test_format_with_conditional_extension_with_extension
+    Phoner::Phone.default_country_code = nil
+    pn = Phoner::Phone.new '5125486', '191', '385', '242'
+    assert_equal pn.format('+ %c (%a) %n%d{ #}%x'), '+ 385 (191) 5125486 #242'
+  end
+
+  def test_format_with_conditional_extension_without_extension
+    Phoner::Phone.default_country_code = nil
+    pn = Phoner::Phone.new '5125486', '191', '385'
+    assert_equal pn.format('+ %c (%a) %n%d{ #}%x'), '+ 385 (191) 5125486'
+  end
+
   def test_validity
     assert true, Phoner::Phone.valid?("+17788827175")
   end


### PR DESCRIPTION
Characters wrapped in `%d{}` only appear when the extension is present. This would be able to be merged in now without changing any of the old behavior and allow an amount of flexibility that is quite useful.
I completely understand if this isn't in the spirit of the gem and doesn't get merged, but I found it useful and thought you might like the idea.