### PR TITLE
Correct area code for ES

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -573,7 +573,7 @@
   :char_3_code: ES
   :name: Spain
   :international_dialing_prefix: "0"
-  :area_code: "6[0-9][0-9]|7[1-9][0-9]|9[0-9][0-9]"  
+  :area_code: "6[0-9][0-9]|7[1-9][0-9]|8[0-9][0-9]|9[0-9][0-9]"  
 "232": 
   :country_code: "232"
   :national_dialing_prefix: "0"


### PR DESCRIPTION
Numbers starting with 8 are valid area code for Spain few years ago
https://en.wikipedia.org/wiki/Telephone_numbers_in_Spain#Area_Codes

That list is not updated, so it's better to allow 8[0-9][0-9]