### PR TITLE
Allow 06x area codes for ZA numbers

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -118,7 +118,7 @@
   :char_3_code: ZA
   :name: South Africa
   :international_dialing_prefix: "0"
-  :area_code: "800|86[01]|[1-57-8]\\d"
+  :area_code: "800|86[01]|[1-8]\\d"
 "508": 
   :country_code: "508"
   :national_dialing_prefix: "0"

--- a/test/countries/za_test.rb
+++ b/test/countries/za_test.rb
@@ -11,6 +11,9 @@ class ZATest < Minitest::Test
   def test_mobile
     # Vodacom
     parse_test('+27 82 555 5555', '27', '82', '5555555')
+
+    # Broader cellular ranges past initial allocation given to telecoms service providers
+    parse_test('+27 62 555 5555', '27', '62', '5555555')
   end
 
   def test_tollfree


### PR DESCRIPTION
Hi,

So, we now allow 06x area codes in ZA, they're all provided by cellular providers. This updates the gem to support these numbers, and not fail when parsing.

Let me know if you need me to do anything else in order to get this merged in.

Thanks :)