### PR TITLE
gemspec: Allow Bundler 2, too

### DIFF
--- a/phone.gemspec
+++ b/phone.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency "bundler", "~> 1.2"
+  gem.add_development_dependency "bundler", ">= 1.2"
   gem.add_development_dependency "minitest", "~> 5.0"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "rubygems-tasks", "~> 0.2"


### PR DESCRIPTION
This PR changes the gemspec to be more permissive, so that latest Bundler can also be used.