### PR TITLE
CI: Use Ruby versions in support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: ruby
 bundler_args: --without doc
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - rbx
-  - rbx-2
-  - jruby
+  - "2.5"
+  - "2.6"
+  - "2.7"
   - ruby-head
   - jruby-head
 matrix:

--- a/test/countries/fr_test.rb
+++ b/test/countries/fr_test.rb
@@ -13,7 +13,7 @@ class FRTest < Minitest::Test
 
   def test_mobile_07
      parse_test('+33 7 11 22 33 44', '33', '7', '11223344')
-   end
+  end
 
   def test_voip
     parse_test('+33 9 11 22 33 44', '33', '9', '11223344')

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -60,8 +60,8 @@ class PhoneTest < Minitest::Test
   end
 
   def test_parse_empty
-    assert_equal Phoner::Phone.parse(''), nil
-    assert_equal Phoner::Phone.parse(nil), nil
+    assert_nil Phoner::Phone.parse('')
+    assert_nil Phoner::Phone.parse(nil)
   end
 
   def test_parse_with_special_characters_with_country
@@ -199,7 +199,7 @@ class PhoneTest < Minitest::Test
   def test_find_by_country_isocode
     Phoner::Country.load
     assert_equal Phoner::Country.find_by_country_isocode('de').country_code, "49"
-    assert_equal Phoner::Country.find_by_country_isocode('xx'), nil
-    assert_equal Phoner::Country.find_by_country_isocode('bla'), nil
+    assert_nil Phoner::Country.find_by_country_isocode('xx')
+    assert_nil Phoner::Country.find_by_country_isocode('bla')
   end
 end

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -4,13 +4,13 @@ class PhoneTest < Minitest::Test
 
   def test_with_nil_number_initialize
     assert_raises Phoner::BlankNumberError do
-      pn = Phoner::Phone.new nil
+      Phoner::Phone.new nil
     end
   end
 
   def test_with_empty_number_initialize
     assert_raises Phoner::BlankNumberError do
-      pn = Phoner::Phone.new ""
+      Phoner::Phone.new ""
     end
   end
 
@@ -18,7 +18,7 @@ class PhoneTest < Minitest::Test
     Phoner::Phone.default_country_code = nil
 
     assert_raises Phoner::CountryCodeError do
-      pn = Phoner::Phone.new '5125486', '91'
+      Phoner::Phone.new '5125486', '91'
     end
   end
 
@@ -27,7 +27,7 @@ class PhoneTest < Minitest::Test
     Phoner::Phone.default_area_code = nil
 
     assert_raises Phoner::AreaCodeError do
-      pn = Phoner::Phone.new '451588'
+      Phoner::Phone.new '451588'
     end
   end
 
@@ -81,7 +81,7 @@ class PhoneTest < Minitest::Test
 
   def test_parse_wont_alter_parameter
     number = "+1 545-545-5454 ext. 4307"
-    parsed = Phoner::Phone.parse number
+    _parsed = Phoner::Phone.parse number
     assert_equal "+1 545-545-5454 ext. 4307", number
   end
 
@@ -89,7 +89,7 @@ class PhoneTest < Minitest::Test
     Phoner::Phone.default_country_code = nil
 
     assert_raises Phoner::CountryCodeError do
-      pn = Phoner::Phone.parse "0915125486"
+      Phoner::Phone.parse "0915125486"
     end
   end
 
@@ -97,7 +97,7 @@ class PhoneTest < Minitest::Test
     Phoner::Phone.default_country_code = nil
 
     assert_raises Phoner::CountryCodeError do
-      pn = Phoner::Phone.parse "091/512-5486"
+      Phoner::Phone.parse "091/512-5486"
     end
   end
 


### PR DESCRIPTION
This PR updates the build matrix to use the Ruby versions which are currently getting support.

  - Ruby maintenance branches: https://www.ruby-lang.org/en/downloads/branches/