### PR TITLE
Allow configurable max number length + some more docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Phone does its best to automatically detect the country and area code while pars
 
 Each country code can have a regular expression named `area_code` that describes what the area code for that particular country looks like.
 
-If an `area_code` regular expression isn't specified, the default, `Phoner::Phone::DEFAULT_AREA_CODE` (correct for the US) is used.
+If an `area_code` regular expression isn't specified, a default value which is considered correct for the US will be used.
+
+If your country has phone numbers longer that 8 digits - exluding country and area code - you can specify that within the country's configuration in `data/phone/countries.yml`
 
 ### Validating
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ Phoner::Phone.default_area_code = '47'
 Phoner::Phone.parse '451-588'
 ```
 
+## Adding and maintaining countries
+
+From time to time, the specifics about your countries information may change. You can add or update your countries configuration by editing `data/phone/countries.yml`
+
+The following are the available attributes for configuration:
+
+* `country_code`: Required. A string representing your country's international dialling code. e.g. "123"
+* `national_dialing_prefix`: Required. A string representing your default dialling prefix for national calls. e.g. "0"
+* `char_3_code`: Required. A string representing a country's ISO code. e.g. "US"
+* `name`: Required. The name of the country. e.g. "Denmark"
+* `international_dialing_prefix`: Required. The dialling prefix a country typically uses when making international calls. e.g. "0"
+* `area_code`: Optional. A regular expression detailing valid area codes. Default: "\d{3}" i.e. any 3 digits.
+* `max_num_length`: Optional. The maximum length of a phone number after country and area codes have been removed. Default: 8
+
 ## Test Countries
 
 * [AU] Australia

--- a/README.md
+++ b/README.md
@@ -201,9 +201,11 @@ There's an issue with Germany and Spanish area codes.
 
     $ gem install phone
 
-Or as a Rails plugin
+Or as a Rails plugin, in your Gemfile
 
-    $ script/plugin install git://github.com/carr/phone.git
+    gem 'phone'
+
+And then `bundle install` from your command line.
 
 ## Copyright
 

--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -118,8 +118,8 @@
   :char_3_code: ZA
   :name: South Africa
   :international_dialing_prefix: "0"
-  :area_code: "800|86[01]|[1-8]\\d"
 "508": 
+  :area_code: "800|86[01]|[1-9]\\d"
   :max_num_length: 11
   :country_code: "508"
   :national_dialing_prefix: "0"

--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -120,6 +120,7 @@
   :international_dialing_prefix: "0"
   :area_code: "800|86[01]|[1-8]\\d"
 "508": 
+  :max_num_length: 11
   :country_code: "508"
   :national_dialing_prefix: "0"
   :char_2_code: "0"

--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -118,9 +118,9 @@
   :char_3_code: ZA
   :name: South Africa
   :international_dialing_prefix: "0"
-"508": 
   :area_code: "800|86[01]|[1-9]\\d"
   :max_num_length: 11
+"508":
   :country_code: "508"
   :national_dialing_prefix: "0"
   :char_2_code: "0"

--- a/lib/phone.rb
+++ b/lib/phone.rb
@@ -52,8 +52,6 @@ module Phoner
     # default length of first number part
     self.n1_length = 3
 
-    # default area code format - any 3 digits
-    DEFAULT_AREA_CODE = "[0-9][0-9][0-9]".freeze
     # common extension patterns
     COMMON_EXTENSIONS = /[ ]*(ext|ex|x|xt|#|:)+[^0-9]*\(*([-0-9]{1,})\)*#?$/i
     # common extra characters and sequences we normalize out
@@ -196,7 +194,7 @@ module Phoner
     end
 
     def self.formats(country)
-      area_code_regexp = country.area_code || DEFAULT_AREA_CODE
+      area_code_regexp = country.area_code
       number_regex     = "([0-9]{1,#{country.max_num_length}})$".freeze
 
       {

--- a/lib/phone.rb
+++ b/lib/phone.rb
@@ -52,8 +52,6 @@ module Phoner
     # default length of first number part
     self.n1_length = 3
 
-    # phone number pattern
-    NUMBER = "([0-9]{1,8})$".freeze
     # default area code format - any 3 digits
     DEFAULT_AREA_CODE = "[0-9][0-9][0-9]".freeze
     # common extension patterns
@@ -199,11 +197,13 @@ module Phoner
 
     def self.formats(country)
       area_code_regexp = country.area_code || DEFAULT_AREA_CODE
+      number_regex     = "([0-9]{1,#{country.max_num_length}})$".freeze
+
       {
         # 047451588, 013668734
-        :short => Regexp.new("^0?(#{area_code_regexp})#{NUMBER}"),
+        :short => Regexp.new("^0?(#{area_code_regexp})#{number_regex}"),
         # 451588
-        :really_short => Regexp.new("^#{NUMBER}")
+        :really_short => Regexp.new("^#{number_regex}")
       }
     end
 

--- a/lib/phone/country.rb
+++ b/lib/phone/country.rb
@@ -1,7 +1,7 @@
 require "yaml"
 
 module Phoner
-  class Country < Struct.new(:name, :country_code, :char_2_code, :char_3_code, :area_code)
+  class Country < Struct.new(:name, :country_code, :char_2_code, :char_3_code, :area_code, :max_num_length)
     module All
       attr_accessor :all
     end
@@ -25,8 +25,10 @@ module Phoner
           c[:char_2_code],
           c[:char_3_code],
           c[:area_code]
+          c.fetch(:max_num_length, 8)
         )
       end
+
       self.all
     end
 

--- a/lib/phone/country.rb
+++ b/lib/phone/country.rb
@@ -24,7 +24,7 @@ module Phoner
           c[:country_code],
           c[:char_2_code],
           c[:char_3_code],
-          c[:area_code]
+          c.fetch(:area_code, "[0-9][0-9][0-9]").freeze,
           c.fetch(:max_num_length, 8)
         )
       end

--- a/test/countries/za_test.rb
+++ b/test/countries/za_test.rb
@@ -22,4 +22,8 @@ class ZATest < Minitest::Test
     parse_test('+27 800 123 321', '27', '800', '123321')
   end
 
+  def test_long_msisdns
+    parse_test('+279602007648699', '27', '96', '02007648699')
+  end
+
 end

--- a/test/countries/za_test.rb
+++ b/test/countries/za_test.rb
@@ -14,6 +14,7 @@ class ZATest < Minitest::Test
 
     # Broader cellular ranges past initial allocation given to telecoms service providers
     parse_test('+27 62 555 5555', '27', '62', '5555555')
+    parse_test('+27 99 555 5555', '27', '99', '5555555')
   end
 
   def test_tollfree


### PR DESCRIPTION
Hi there,

South Africa has recently updated the maximum number length to 11, up from 8. As a result they were no longer parsing.

I've made it so that the Country object owns the notion of how long its numbers are allowed to be, and it can be overridden from the YAML config as an optional param.

I've also done the same for `area_code`s. The country object contains the default value, and will supply it if the YAML data doesn't. This cleans up the codebase with a few constants that didn't really belong.

Finally, I've updated the documentation to reflect these changes, and provided some instructions for maintaining (or even adding) countries in the YAML file.

Hope you find these changes useful :)