### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/phone.gemspec
+++ b/phone.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/carr/phone#readme"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This PR removes an unused line in the gemspec.