### PR TITLE
Add 92 area code for portuguese mobile phones validation

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -961,7 +961,7 @@
   :char_3_code: PT
   :name: Portugal
   :international_dialing_prefix: "0"
-  :area_code: "2[12]|2[3-9][1-9]|70[78]|80[089]|9[136]|92[1-9]"
+  :area_code: "21|22|2[3-9][1-9]|70[78]|80[089]|9[1236]|92[1-9]"
 "973": 
   :country_code: "973"
   :national_dialing_prefix: None


### PR DESCRIPTION
Right now Phone's validation for portuguese indicative 92 created in 2007.
This PR fixes that.

Thank you for your work