### PR TITLE
Update Belgium area codes

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -416,7 +416,7 @@
   :char_3_code: BE
   :name: Belgium
   :international_dialing_prefix: "0"
-  :area_code: "800|90\\d|2|3|4|9|1[0-69]|5\\d|6[013-9]|7[01]|8[1-9]"
+  :area_code: "800|90\\d|2|3|4|9|1[0-69]|5\\d|6[013-9]|7[0178]|8[1-9]"
 "965": 
   :country_code: "965"
   :national_dialing_prefix: None


### PR DESCRIPTION
This PR adds two Belgium area codes that should be considered valid.

- 077: Machine to machine communication
- 078: National pay rate services

As seen in the Wikipedia page https://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium and http://www.wtng.info/ccod-32.html#CC32